### PR TITLE
Updated Void version from 20190217 to 20190526

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LNCR_EXE=VoidMusl.exe
 
 DLR=curl
 DLR_FLAGS=-L
-BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190217/void-x86_64-musl-ROOTFS-20190217.tar.xz
+BASE_URL=http://alpha.de.repo.voidlinux.org/live/20190526/void-x86_64-musl-ROOTFS-20190526.tar.xz
 LNCR_ZIP_URL=https://github.com/yuk7/wsldl/releases/download/19022600/icons.zip
 LNCR_ZIP_EXE=Void.exe
 


### PR DESCRIPTION
Update includes later version of xbps which works behind ntlm proxy. Sorry for the delay